### PR TITLE
Add setup for LHAPDF

### DIFF
--- a/LHAPDF.csh
+++ b/LHAPDF.csh
@@ -1,0 +1,34 @@
+#!/bin/csh
+
+if ($?CMSSW_BASE) then 
+  echo $CMSSW_BASE
+  setenv LHAPDF_INCLUDE `scram tool info lhapdf | grep ROOT_INCLUDE_PATH | cut -d= -f2`
+  setenv LHAPDF_LIBDIR `scram tool info lhapdf | grep LIBDIR | cut -d= -f2`
+  setenv LHAPDF_DATA_PATH /cvmfs/sft.cern.ch/lcg/external/lhapdfsets/current/
+  echo $LHAPDF_INCLUDE 
+  echo $LHAPDF_LIBDIR
+  echo $LHAPDF_DATA_PATH
+  return 1
+endif
+
+set PDFList=(NNPDF30_nlo_as_0118 CT10nlo MMHT2014nlo68cl)
+if ( ! -d LHAPDF) then
+  wget  http://www.hepforge.org/archive/lhapdf/LHAPDF-6.1.5.tar.gz -O- | tar xz -C ./
+  mv LHAPDF-6.1.5 LHAPDF
+  cd LHAPDF
+  mkdir build
+  ./configure --disable-python --prefix=$PWD/build
+  make -j 4
+  make install
+  cd -
+endif
+setenv LHAPDF_INCLUDE $PWD/LHAPDF/build/include
+setenv LHAPDF_LIBDIR $PWD/LHAPDF/build/lib
+setenv LHAPDF_DATA_PATH $PWD/LHAPDF/build/share
+setenv PATH $PWD/build/bin:$PATH
+foreach PDF ($PDFList)
+  echo $PDF
+  if (! -d $LHAPDF_DATA_PATH/$PDF) then
+    wget http://www.hepforge.org/archive/lhapdf/pdfsets/6.1/${PDF}.tar.gz -O- | tar xz -C $LHAPDF_DATA_PATH
+  endif
+end

--- a/README.md
+++ b/README.md
@@ -1,3 +1,15 @@
 recipeAUX
 ===============
 Works in CMSSW_7_1_0_pre8
+
+*Setup LHAPDF*
+
+- cd recipeAUX
+- source LHAPDF.csh
+
+It will setup enviromental variable:
+- $LHAPDF\_INCLUDE : For include path of LHAPDF header
+- $LHAPDF_LIBDIR : For shared library location of LHAPDF
+- $LHAPDF_DATA_PATH : The dataset location of PDFsets. On LPC/Lxplus, it
+included all the current PDFSet. On local machines, it downloads NNPDF30_nlo_as_0118,
+CT10nlo and MMHT2014nlo68cl so far.


### PR DESCRIPTION
Ops, this pull request was sent to hongxuan's respo.....

Add setup script for LHAPDF. On cmslpc/lxplus, it will use the CMSSW version and
point to the current location of all the PDFsets.

On laptop, it will download the package and compile.
